### PR TITLE
geofenceを削除する際、localstorage の情報を先に消していたので、消した直後の

### DIFF
--- a/src/android/GeoNotificationManager.java
+++ b/src/android/GeoNotificationManager.java
@@ -129,10 +129,10 @@ public class GeoNotificationManager {
                 }
             });
         }
+        googleServiceCommandExecutor.QueueToExecute(cmd);
         for (String id : ids) {
             geoNotificationStore.remove(id);
         }
-        googleServiceCommandExecutor.QueueToExecute(cmd);
     }
 
     public void removeAllGeoNotifications(final CallbackContext callback) {


### PR DESCRIPTION
オリジナルの removeAll処理の不具合を修正した。
